### PR TITLE
Проверка корректности состояния автомобиля для назначения на заказ вынесена отдельно перед назначением заказа автомобилю

### DIFF
--- a/main_service/app/crud.py
+++ b/main_service/app/crud.py
@@ -363,9 +363,6 @@ def assign_car_to_order_in_db(db:Session, order_id: int, car_id: int) -> CarStat
             car_id=car_id, 
             order_id=order_id
         )
-    elif car_status.status in (carStatuses["broken"], carStatuses["driver_missing"]):
-        raise HTTPException(
-            status_code=404, detail=f"Car is in status {car_status.status} and can't be assigned to order")
     else:
         car_status.status = carStatuses["busy"]
         car_status.order_id = order_id

--- a/main_service/app/endpoints/orders.py
+++ b/main_service/app/endpoints/orders.py
@@ -124,9 +124,16 @@ def assign_car_to_order(
     new_orderstatus.comment = comment
     new_orderstatus.start_at = datetime.now()
 
+    # Поиск последнего состояния автомобиля
+    car_status = get_carstatus_in_db(db=db, car_id=car_id)
+    # Проверка корректности состояния автомобиля для назначения на заказ
+    if car_status.status in (carStatuses["broken"], carStatuses["driver_missing"]):
+        raise HTTPException(
+            status_code=404, detail=f"Car is in status {car_status.status} and can't be assigned to order")    
+
     db_orderstatus = add_new_orderstatus_in_db(db, new_orderstatus=new_orderstatus) 
 
-    db_car_status = assign_car_to_order_in_db(db=db, order_id=order_id, car_id=car_id)
+    assign_car_to_order_in_db(db=db, order_id=order_id, car_id=car_id)
 
     return OrderStatus(**db_orderstatus.model_dump())
 
@@ -198,7 +205,7 @@ def complete_order(
     new_orderstatus.finish_at = datetime.now()
 
     db_orderstatus = add_new_orderstatus_in_db(db, new_orderstatus=new_orderstatus) 
-
+    
     return OrderStatus(**db_orderstatus.model_dump())
 
 


### PR DESCRIPTION
Ошибка заключалась в том что последовательно исполнялись две процедуры:
- add_new_orderstatus_in_db
- assign_car_to_order_in_db

В каждой из которых стояли проверки и commit/refresh.

Первая исполнилась, на второй проверка упала - но комит первой уже исполнился.

Исправлено переносом проверок второй процедуры в начало обработки. Но по хорошему из процедур лучше вовсе убирать comit и делать его централизовано в процедуре точки входа в обработку, но тогда не проходит валидацию OrderStatus.model_validate(db_order_status) так как без комита отсутствует ID